### PR TITLE
Update workflow to tag the commit with the version when publishing NuGet packages.

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Tag Commit
       run: |
         $versionTag = "v${{ steps.determineVersion.outputs.semVer }}"
-        echo $versionTag
-        # git tag v
-        # git push origin --tags
+        echo "Tagging Commit with $versionTag"
+        git tag $versionTag
+        git push origin --tags
 
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -37,7 +37,8 @@ jobs:
     #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
     - name: Tag Commit
       run: |
-        echo "${{ steps.determineVersion.outputs.semVer }}"
+        $versionTag = "v${{ steps.determineVersion.outputs.semVer }}"
+        echo $versionTag
         # git tag v
         # git push origin --tags
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -46,6 +46,13 @@ jobs:
       uses: gittools/actions/gitversion/command@v3.0.0
       with:
         arguments: /output json /output buildserver /config GitVersion.yml /updateprojectfiles
+        
+    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+    - name: Tag Commit
+      run: |
+        echo ${{ steps.updateVersion.outputs.semVer }}
+        # git tag v
+        # git push origin --tags
 
     - name: Restore dependencies
       run: |
@@ -58,12 +65,6 @@ jobs:
     - name: Test
       run: |
         dotnet test --configuration Release --no-restore --no-build --verbosity normal
-        
-    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-    - name: Tag Commit
-      run: |
-        git tag v${{ steps.updateVersion.outputs.semVer }}
-        git push origin --tags
         
     # - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
     #   name: Pack

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -33,14 +33,6 @@ jobs:
       uses: gittools/actions/gitversion/execute@v3.0.0
       with:
         useConfigFile: true
-        
-    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-    - name: Tag Commit
-      run: |
-        $versionTag = "v${{ steps.determineVersion.outputs.semVer }}"
-        echo "Tagging Commit with $versionTag"
-        git tag $versionTag
-        git push origin --tags
 
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
@@ -49,9 +41,8 @@ jobs:
           6.0.x
           8.0.x
           
-    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-    - name: Update Version
-      id: updateVersion
+    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+      name: Update Version
       uses: gittools/actions/gitversion/command@v3.0.0
       with:
         arguments: /output json /output buildserver /config GitVersion.yml /updateprojectfiles
@@ -68,15 +59,23 @@ jobs:
       run: |
         dotnet test --configuration Release --no-restore --no-build --verbosity normal
         
-    # - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-    #   name: Pack
-    #   run: |
-    #     dotnet pack "src/TFeatureManagement/TFeatureManagement.csproj" --configuration Release --no-restore --no-build
-    #     dotnet pack "src/TFeatureManagement.Abstractions/TFeatureManagement.Abstractions.csproj" --configuration Release --no-restore --no-build
-    #     dotnet pack "src/TFeatureManagement.AspNetCore/TFeatureManagement.AspNetCore.csproj" --configuration Release --no-restore --no-build
-    #     dotnet pack "src/TFeatureManagement.AspNetCore.Abstractions/TFeatureManagement.AspNetCore.Abstractions.csproj" --configuration Release --no-restore --no-build
+    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+      name: Tag Commit
+      run: |
+        $versionTag = "v${{ steps.determineVersion.outputs.semVer }}"
+        echo "Tagging commit with $versionTag"
+        git tag $versionTag
+        git push origin --tags
+        
+    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+      name: Pack
+      run: |
+        dotnet pack "src/TFeatureManagement/TFeatureManagement.csproj" --configuration Release --no-restore --no-build
+        dotnet pack "src/TFeatureManagement.Abstractions/TFeatureManagement.Abstractions.csproj" --configuration Release --no-restore --no-build
+        dotnet pack "src/TFeatureManagement.AspNetCore/TFeatureManagement.AspNetCore.csproj" --configuration Release --no-restore --no-build
+        dotnet pack "src/TFeatureManagement.AspNetCore.Abstractions/TFeatureManagement.AspNetCore.Abstractions.csproj" --configuration Release --no-restore --no-build
 
-    # - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-    #   name: Publish NuGet packages
-    #   run: |
-    #     dotnet nuget push "**/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --no-symbols
+    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+      name: Publish NuGet packages
+      run: |
+        dotnet nuget push "**/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --no-symbols

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,9 +29,17 @@ jobs:
         versionSpec: '6.x'
 
     - name: Determine Version
+      id: determineVersion
       uses: gittools/actions/gitversion/execute@v3.0.0
       with:
         useConfigFile: true
+        
+    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+    - name: Tag Commit
+      run: |
+        echo "${{ steps.determineVersion.outputs.semVer }}"
+        # git tag v
+        # git push origin --tags
 
     - name: Setup dotnet
       uses: actions/setup-dotnet@v4
@@ -46,13 +54,6 @@ jobs:
       uses: gittools/actions/gitversion/command@v3.0.0
       with:
         arguments: /output json /output buildserver /config GitVersion.yml /updateprojectfiles
-        
-    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-    - name: Tag Commit
-      run: |
-        echo ${{ steps.updateVersion.outputs.semVer }}
-        # git tag v
-        # git push origin --tags
 
     - name: Restore dependencies
       run: |

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,8 +40,8 @@ jobs:
           6.0.x
           8.0.x
           
-    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-      name: Update Version
+    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+    - name: Update Version
       id: updateVersion
       uses: gittools/actions/gitversion/command@v3.0.0
       with:
@@ -59,21 +59,21 @@ jobs:
       run: |
         dotnet test --configuration Release --no-restore --no-build --verbosity normal
         
-    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-      name: Tag Commit
+    #- if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+    - name: Tag Commit
       run: |
         git tag v${{ steps.updateVersion.outputs.semVer }}
         git push origin --tags
         
-    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-      name: Pack
-      run: |
-        dotnet pack "src/TFeatureManagement/TFeatureManagement.csproj" --configuration Release --no-restore --no-build
-        dotnet pack "src/TFeatureManagement.Abstractions/TFeatureManagement.Abstractions.csproj" --configuration Release --no-restore --no-build
-        dotnet pack "src/TFeatureManagement.AspNetCore/TFeatureManagement.AspNetCore.csproj" --configuration Release --no-restore --no-build
-        dotnet pack "src/TFeatureManagement.AspNetCore.Abstractions/TFeatureManagement.AspNetCore.Abstractions.csproj" --configuration Release --no-restore --no-build
+    # - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+    #   name: Pack
+    #   run: |
+    #     dotnet pack "src/TFeatureManagement/TFeatureManagement.csproj" --configuration Release --no-restore --no-build
+    #     dotnet pack "src/TFeatureManagement.Abstractions/TFeatureManagement.Abstractions.csproj" --configuration Release --no-restore --no-build
+    #     dotnet pack "src/TFeatureManagement.AspNetCore/TFeatureManagement.AspNetCore.csproj" --configuration Release --no-restore --no-build
+    #     dotnet pack "src/TFeatureManagement.AspNetCore.Abstractions/TFeatureManagement.AspNetCore.Abstractions.csproj" --configuration Release --no-restore --no-build
 
-    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
-      name: Publish NuGet packages
-      run: |
-        dotnet nuget push "**/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --no-symbols
+    # - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+    #   name: Publish NuGet packages
+    #   run: |
+    #     dotnet nuget push "**/*.nupkg" --source "https://api.nuget.org/v3/index.json" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --no-symbols

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -42,6 +42,7 @@ jobs:
           
     - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
       name: Update Version
+      id: updateVersion
       uses: gittools/actions/gitversion/command@v3.0.0
       with:
         arguments: /output json /output buildserver /config GitVersion.yml /updateprojectfiles
@@ -57,6 +58,12 @@ jobs:
     - name: Test
       run: |
         dotnet test --configuration Release --no-restore --no-build --verbosity normal
+        
+    - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
+      name: Tag Commit
+      run: |
+        git tag v${{ steps.updateVersion.outputs.semVer }}
+        git push origin --tags
         
     - if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && inputs.publish_nuget_packages }}
       name: Pack


### PR DESCRIPTION
Part 2 of fix for #90 